### PR TITLE
resource problem fix

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+graft geodata/resources

--- a/geodata/resource.py
+++ b/geodata/resource.py
@@ -37,15 +37,13 @@ def get_windturbineconfig(turbine):
     """Load the 'turbine'.yaml file from local disk and provide a turbine dict."""
 
     res_name = "resources/windturbine/"+ turbine + ".yaml"
-    res_name = 'E:/Rambo!!!!/geodata/geodata/geodata/resources/windturbine/' + turbine + ".yaml"
-    with open(res_name, 'r') as file_data:
-                    yaml_data = file_data.read()
-    #turbineconf = yaml.safe_load(resource_stream('E:/Rambo!!!!/geodata/geodata/geodata', res_name))
-    turbineconf = yaml.safe_load(yaml_data)
+    turbineconf = yaml.safe_load(resource_stream(__name__, res_name))
     V, POW, hub_height = itemgetter('V', 'POW', 'HUB_HEIGHT')(turbineconf)
     return dict(V=np.array(V), POW=np.array(POW), hub_height=hub_height, P=np.max(POW))
 
 def get_solarpanelconfig(panel):
+    """Load the 'panel'.yaml file from local disk and provide a panel dict."""
+
     res_name = "resources/solarpanel/" + panel + ".yaml"
     return yaml.safe_load(resource_stream(__name__, res_name))
 


### PR DESCRIPTION
The geodata.convert.wind() function cannot find the yaml file. This is a way I used to solve this problem. I typed in the path of the resource folder to locate the yaml file. To make this fix work, manually changing the path of the resource package in resource.py is needed.