### PR TITLE
GEE Modis Landcover get_data method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 ## Unreleased
 
+## Modis Get Data method - draft
+### dataset.py
+* Added entry for modis data source to construction of download file list (L198).  This calls out the modis config by name explicitly but if additional GEE data sources were added at the yearly level, this block could be modified to be common to all yearly GEE sources.
+* Added call to modis api function in get_data() block.
+
+
+
+
+### modis.py
+* Added config + functions for modis land cover data downloads via GEE python API.  Contains two items:
+- api_modis() - in progress function for downloading modis landcover data (see PR for full notes: https://github.com/east-winds/geodata/pull/36).
+- weather config for modis land cover data.  (see PR for full notes: https://github.com/east-winds/geodata/pull/36)
+
+
 ## preparation.py
 * Added lines to close tempfiles.  This was causing Win32 permissions issues for windows machines.
 

--- a/geodata/dataset.py
+++ b/geodata/dataset.py
@@ -197,21 +197,25 @@ class Dataset(object):
 		
 		elif self.config == 'modis_land_cover':
 			for yr in yrs:
-				filename = self.datasetfn(self.weatherconfig['fn'], yr)
-				self.totalFiles.append((self.config, filename))
-				if not os.path.isfile( filename ):
+				nc_filename = self.datasetfn(self.weatherconfig['nc_fn'], yr)
+				tif_filename = self.datasetfn(self.weatherconfig['tif_fn'], yr)
+				image_name = self.datasetfn(self.weatherconfig['image'], yr)
+				self.totalFiles.append((self.config, nc_filename))
+				if not os.path.isfile( nc_filename ):
 					self.prepared = False
 					if check_complete:
-						logger.info("File `%s` not found!", filename)
+						logger.info("File `%s` not found!", nc_filename)
 						incomplete_count += 1
 					self.toDownload.append((
 						self.config, 
-						filename, 
+						nc_filename, 
+						tif_filename,
+						image_name,
 						self.bounds,
 						self.weatherconfig['band']
 						))
 				else:
-					self.downloadedFiles.append((self.config, filename))
+					self.downloadedFiles.append((self.config, nc_filename))
 
 		if not self.prepared:
 
@@ -271,6 +275,13 @@ class Dataset(object):
 			api_func(
 				self.toDownload,
 				self.weatherconfig['file_granularity'],
+				self.downloadedFiles
+			)
+		
+		elif self.module == 'modis':
+
+			api_func(
+				self.toDownload,
 				self.downloadedFiles
 			)
 

--- a/geodata/datasets/__init__.py
+++ b/geodata/datasets/__init__.py
@@ -1,3 +1,3 @@
 from __future__ import absolute_import
 
-from . import cordex, ncep, era5, sarah, merra2
+from . import cordex, ncep, era5, sarah, merra2, modis

--- a/geodata/datasets/modis.py
+++ b/geodata/datasets/modis.py
@@ -1,0 +1,62 @@
+## Copyright 2020 Michael Davidson (UCSD), William Honaker.
+
+## This program is free software; you can redistribute it and/or
+## modify it under the terms of the GNU General Public License as
+## published by the Free Software Foundation; either version 3 of the
+## License, or (at your option) any later version.
+
+## This program is distributed in the hope that it will be useful,
+## but WITHOUT ANY WARRANTY; without even the implied warranty of
+## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+## GNU General Public License for more details.
+
+## You should have received a copy of the GNU General Public License
+## along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""
+GEODATA
+
+Geospatial Data Collection and "Pre-Analysis" Tools
+"""
+
+import os
+import glob
+import pandas as pd
+import numpy as np
+import xarray as xr
+import shutil
+import requests
+from requests.exceptions import HTTPError
+from six.moves import range
+from contextlib import contextmanager
+from tempfile import mkstemp
+from calendar import monthrange
+
+import logging
+logger = logging.getLogger(__name__)
+
+from ..config import modis_dir
+
+datadir = modis_dir
+spinup_var = False
+
+
+def api_modis(
+    toDownload,
+    downloadedFiles
+    ):
+    if len(toDownload) == 0:
+        logger.info("All MERRA2 files for this dataset have been downloaded.")
+    else:
+        count = 0
+        print("get data goes here")
+
+
+weather_data_config = {
+	'modis_land_cover': dict(
+		api_func=api_modis,
+		file_granularity="yearly",
+        band="LC_Type1",
+		fn = os.path.join(modis_dir, '{year}/MODIS_006_MCD12Q1_{year}_01_01.nc')
+	)
+}


### PR DESCRIPTION
PR for adding download method from GEE for MODIS landcover dataset to geodata.
Data source: https://developers.google.com/earth-engine/datasets/catalog/MODIS_006_MCD12Q1

## What's been added

### dataset.py
- To declare a dataset for "modis", need to specify following parameters as in the following example:
 ```
geodata.Dataset(module="modis",
			    years=slice(2010, 2014),
                            bounds = [73, 17, 83, 27],
                            weather_data_config = "modis_land_cover")  
```
- **bounds** needs to be specified as [North, West, South, East].  GEE cannot output a full global image via API as pixel limit for query is usually exceeded.



### modis.py.
- New config file for modis landcover dataset.  Includes two components:
#### Modis landcover weather data config
Contains the following GEE specific parameters:
- **band** - specifies band to pull and transform into xarray dataset from GEE image (which can have multiple bands).
- **image** - template value for each data period's image.  Download function will take each year(or month, depending on available time granularity) and construct an image path for that year to download the image from GEE.
- **nc_fn** and **tif_fn** - download function needs to download GEE image data as TIFF, and then reimport the TIFF file for conversion of data to NetCDF format.  Accordingly, filenames for both the TIFF file (tif_fn) and (nc_fn).  A more ideal approach might directly convert the image data into xarray data without needing to write to a TIFF first.  Or, write TIFF as a temporary file and clear from memory when finished.
Possible ways to improve in future:
- Could change "band" to be a user input at dataset declaration, instead of hardcoding in weather data config.

#### Modis data download method
Takes following parameters:
- list of toDownload objects (generated during dataset declaration)
- list of downloaded files (generated during dataset declaration)
From each toDownload object, makes call to GEE using img, area bounds ("bounds" in original dataset declaration) and band.
General workflow:
1.  Select image and band
2.  Reduce data in band to indicated bounds (.reduceRegion()) - maxPixels + scale parameters here could be bubbled up into api function parameters)
3.  Convert image to np arrays, convert to raster, and export as tiff.
4.  Use gdal.Translate function to convert tiff file to netcdf file.


## Needed to get working

Need to figure out how to properly incorporate `ee.Authenticate()` and `ee.Initialize` so that GEE API runs properly when function is invoked.  See comment below for error that occurs when code is run in current state:

