### PR TITLE
Update ERA5 documentation to account for separation of both download and cutout create steps

### DIFF
--- a/doc/era5/era5_download.md
+++ b/doc/era5/era5_download.md
@@ -2,11 +2,11 @@ Back to the [Table of Contents](https://github.com/east-winds/geodata/blob/maste
 
 # Downloading ERA5 Data and creating ERA5 Cutouts
 
-A short guide to downloading ERA5 data from the [Copernicus Data Store](https://cds.climate.copernicus.eu/cdsapp#!/dataset/reanalysis-era5-single-levels?tab=overview).
+A short guide to using **geodata** to downloading and creating cutouts from ERA5 data from the [Copernicus Data Store](https://cds.climate.copernicus.eu/cdsapp#!/dataset/reanalysis-era5-single-levels?tab=overview).
 
 ## Download using the geodata package itself
 
-Downloading ERA5 data and creating ERA5-based cutouts can be achieved in the same step.
+Download methods for ERA5 data are built into the **geodata** package.  A basic example is as follows:
 
 
 To start, import the required dependencies:
@@ -15,9 +15,67 @@ To start, import the required dependencies:
 import logging
 logging.basicConfig(level=logging.INFO)
 import geodata
+
+DS = geodata.Dataset(module="era5",
+                     weather_data_config="wind_solar_hourly",
+                     years=slice(2005, 2005),
+                     months=slice(1,2),
+                     bounds=[50, -3, 45, 3])
+
+if DS.prepared == False:
+	DS.get_data()
+
+DS.trim_variables(downloadedfiles = True)
 ```
 
-`import geodata` is required to use **geodata**, while launching a logger allows for detailed debugging via the console.
+Let's breakdown the code above:
+
+```
+import logging
+logging.basicConfig(level=logging.INFO)
+import geodata
+```
+Importing the logging package allows **geodata** to generate console input for download status, errors, etc.
+Importing geodata is necessary to run **geodata**.
+
+```
+DS = geodata.Dataset(module="era5",
+                     weather_data_config="wind_solar_hourly",
+                     years=slice(2005, 2005),
+                     months=slice(1,2),
+                     bounds=[50, -3, 45, 3])
+```
+
+`geodata.Dataset()` creates a dataset object via which you can download data files.  To create objects for ERA5 data, specify `module="era5"`.  You must also have configured `era5_dir` in `config.py` to point to a directory on your local machine  (to set up `config.py`, [see here](https://github.com/east-winds/geodata/blob/master/doc/general/packagesetup.md)).
+
+The `years` and `months` parameters allow you to specify start years/months and end years/months for the data download.  The above example would download data for January to February 2005.  Ranges based on more granular time periods (such as day or hour) are not currently supported, but may be available in a future release.
+
+Running the above code does not actually download the data yet.  Instead, it checks whether the indicated files for download are present in the local directory specified in `config.py`:
+
+```
+>> INFO:geodata.dataset:Directory /Users/johndoe/desktop/geodata/data/era5 found, checking for completeness.
+>> INFO:geodata.dataset:Directory complete.
+```
+
+and returns a `dataset` object indicating whether the data is "prepared."
+
+```
+<Dataset merra2 years=2005-2005 months=1-2 datadir=/Users/johndoe/desktop/geodata/data/era5 Prepared>
+```
+
+A "prepared" dataset indicates that the directories for storing the data - which take the form `/era5/{years}/{months}` for every unique time period in the data - have been created and are populated with downloaded data.  
+
+```
+if DS.prepared == False:
+	DS.get_data()
+```
+If the dataset is "Unprepared", this conditional statement will download the actual netcdf files from the ERA5 CDS API.
+
+
+```
+DS.trim_variables(downloadedfiles = True)
+```
+To save hard disk space, **geodata** allows you to trim the downloaded datasets to just the variables needed for the package's supported outputs.
 
 ## Preparing the cutout
 
@@ -50,36 +108,17 @@ module="era5"
 
 `years` and `months` are used to subset the time range.  For both functions, the first value represents the start point, and the second value represents the end point.  The above example creates a cutout for January 2011.
 
-## Downloading Data and Creating a Cutout
+## Creating the Cutout
 
-To download data and create a cutout, run:
+To create a cutout, run:
 ```
 cutout.prepare();
 ```
-The **geodata** package will create a folder in the cutout directory (`cutout_dir`) you specified in `config.py` with the name specified in `geodata.Cutout()` (in the above example, `merra2-europe-sub24-2011-01`).  The folder, depending on the date range, will then contain one or more monthly netcdf files containing ERA5 data corresponding to the temporal and geographical ranges indicated when the cutout was created.  Data files in the cutout folder will be at the monthly level - i.e., there will be one file for each month in the specified download time range.
+The **geodata** package will create a folder in the cutout directory (`cutout_dir`) you specified in `config.py` with the name specified in `geodata.Cutout()` (in the above example, `era5-europe-test-2011-01`).  The folder, depending on the date range, will then contain one or more monthly netcdf files containing ERA5 data corresponding to the temporal and geographical ranges indicated when the cutout was created.  Data files in the cutout folder will be at the monthly level - i.e., there will be one file for each month in the specified download time range.
 
 
 To actually create the cutout, you must run `cutout.prepare()`.  Upon running `cutout.prepare()`, **geodata** will check for the presence of the cutout and abort if the cutout already exists.  If you want to force the regeneration of a cutout, run the command with the parameter `overwrite=True`.
 
-
-### Notes on Downloading ERA5 data
-
-If the specified cutout does not yet exist, or if `overwrite=True` is specified in `cutout.prepare()`, **geodata** will initiate data download.  Depending on your specified time range and internet connection speed, this step could take several minutes or even hours.
-
-
-If downloaded through `cutout.prepare()`, ERA5 data will download with the following variables:
-
-* temperature: 2 metre temperature (K)
-* runoff
-* soil temperature: Soil temperature level 4 (K)
-* pressure: Surface pressure (Pa)
-* influx_toa (W m**-2)
-* influx_direct (W m**-2)
-* roughness: Forecast surface roughness (m)
-* albedo (0-1)
-* influx_diffuse (W m**-2)
-* wnd100m (100 metre wind speed) 
-* height
 
 
 ## Cutout Metadata
@@ -137,4 +176,58 @@ Attributes:
     view:         {'x': slice(30, 41.56244222, None), 'y': slice(35, 33.56459...
 ```
 
+To understand the variables that were downloaded, you can run:
+```
+cutout.dataset_module.weather_data_config
+```
+
+Which will return the selected download settings for the ERA5 data.
+
+```
+{'wind_solar_hourly': {'api_func': <function geodata.datasets.era5.api_hourly_era5(toDownload, bounds, download_vars, product, product_type)>,
+  'file_granularity': 'monthly',
+  'tasks_func': <function geodata.datasets.era5.tasks_monthly_era5(xs, ys, yearmonths, prepare_func, **meta_attrs)>,
+  'meta_prepare_func': <function geodata.datasets.era5.prepare_meta_era5(xs, ys, year, month, template, module, **kwargs)>,
+  'prepare_func': <function geodata.datasets.era5.prepare_month_era5(fn, year, month, xs, ys)>,
+  'template': '/Users/johndoe/data_for_geodata/era5/{year}/{month:0>2}/wind_solar_hourly.nc',
+  'fn': '/Users/johndoe/data_for_geodata/era5/{year}/{month:0>2}/wind_solar_hourly.nc',
+  'product': 'reanalysis-era5-single-levels',
+  'product_type': 'reanalysis',
+  'variables': ['100m_u_component_of_wind',
+   '100m_v_component_of_wind',
+   '2m_temperature',
+   'runoff',
+   'soil_temperature_level_4',
+   'surface_net_solar_radiation',
+   'surface_pressure',
+   'surface_solar_radiation_downwards',
+   'toa_incident_solar_radiation',
+   'total_sky_direct_solar_radiation_at_surface',
+   'forecast_surface_roughness',
+   'orography'],
+  'meta_attrs': {'Conventions': 'CF-1.6',
+   'history': '2022-01-11 00:43:10 GMT by grib_to_netcdf-2.23.0: /opt/ecmwf/mars-client/bin/grib_to_netcdf -S param -o /cache/data3/adaptor.mars.internal-1641861772.7584445-3425-17-8ff8bcdc-2c08-4aed-95db-e0337692a384.nc /cache/tmp/8ff8bcdc-2c08-4aed-95db-e0337692a384-adaptor.mars.internal-1641861207.3577378-3425-30-tmp.grib',
+   'module': 'era5'}},
+ 'wind_solar_monthly': {'api_func': <function geodata.datasets.era5.api_monthly_era5(toDownload, bounds, download_vars, product, product_type)>,
+  'file_granularity': 'monthly',
+  'tasks_func': <function geodata.datasets.era5.tasks_monthly_era5(xs, ys, yearmonths, prepare_func, **meta_attrs)>,
+  'meta_prepare_func': <function geodata.datasets.era5.prepare_meta_era5(xs, ys, year, month, template, module, **kwargs)>,
+  'prepare_func': <function geodata.datasets.era5.prepare_month_era5(fn, year, month, xs, ys)>,
+  'template': '/Users/johndoe/data_for_geodata/era5/{year}/{month:0>2}/wind_solar_monthly.nc',
+  'fn': '/Users/johndoe/data_for_geodata/era5/{year}/{month:0>2}/wind_solar_monthly.nc',
+  'product': 'reanalysis-era5-single-levels-monthly-means',
+  'product_type': 'monthly_averaged_reanalysis',
+  'variables': ['100m_u_component_of_wind',
+   '100m_v_component_of_wind',
+   '2m_temperature',
+   'runoff',
+   'soil_temperature_level_4',
+   'surface_net_solar_radiation',
+   'surface_pressure',
+   'surface_solar_radiation_downwards',
+   'toa_incident_solar_radiation',
+   'total_sky_direct_solar_radiation_at_surface',
+   'forecast_surface_roughness',
+   'orography']}}
+```
 

--- a/doc/merra2/merra2_download.md
+++ b/doc/merra2/merra2_download.md
@@ -2,7 +2,7 @@ Back to the [Table of Contents](https://github.com/east-winds/geodata/blob/maste
 
 # Downloading MERRA2 Data and creating MERRA2 Cutouts
 
-A short guide to use **geodata** to download MERRA2 data, and create cutouts - subsets of data based on specific time and geographic ranges - for [MERRA2 hourly, single-level surface flux diagnostics](https://disc.gsfc.nasa.gov/datasets/M2T1NXFLX_5.12.4/summary).
+A short guide to using **geodata** to download MERRA2 data, and create cutouts - subsets of data based on specific time and geographic ranges - for [MERRA2 hourly, single-level surface flux diagnostics](https://disc.gsfc.nasa.gov/datasets/M2T1NXFLX_5.12.4/summary).
 
 **Geodata** is currently optimized to work with the following MERRA2 datasets:
 * [MERRA2 hourly, single-level surface flux diagnostics](https://disc.gsfc.nasa.gov/datasets/M2T1NXFLX_5.12.4/summary)
@@ -66,7 +66,7 @@ Running the above code does not actually download the data yet.  Instead, it che
 and returns a `dataset` object indicating whether the data is "prepared."
 
 ```
-<Dataset merra2 years=2012-2012 months=2-2 datadir=/Users/williamhonaker/desktop/davidson/data_for_geodata/merra2 Prepared>
+<Dataset merra2 years=2012-2012 months=2-2 datadir=/Users/johndoe/desktop/geodata/data/merra2 Prepared>
 ```
 
 A "prepared" dataset indicates that the directories for storing the data - which take the form `/merra2/{years}` (or `/merra2/{years}/{months}` for hourly data) for every unique time period in the data - have been created and are populated with downloaded data.  
@@ -81,7 +81,7 @@ Files for the MERRA2 hourly, single-level surface flux diagnostics will be downl
 
 Each daily file is about 400mb in size, and contains all 46 variables detailed under the "Subset/Get Data" tab here: [MERRA2 hourly, single-level surface flux diagnostics](https://disc.gsfc.nasa.gov/datasets/M2T1NXFLX_5.12.4/summary).
 
-Files for the MERRA2 monthly, single-level surface flux diagnostics will be downloaded at the monthly level, meaning that if you download data fo January 2011 to June 2011, 6 monthly files will download to the directory `/merra2/2011`.  These files contain the same variables as the hourly dataset described above.
+Files for the MERRA2 monthly, single-level surface flux diagnostics will be downloaded at the monthly level, meaning that if you download data for January 2011 to June 2011, 6 monthly files will download to the directory `/merra2/2011`.  These files contain the same variables as the hourly dataset described above.
 
 
 


### PR DESCRIPTION
Previously, documentation had referenced old functionality in which files were downloaded and cutout created in just one step.

## Summary of changes
### doc/era5/era5_download.md
* Change to account for separate download and cutout creation.
### doc/merra2/merra2_download.md
* Fix typos.