### PR TITLE
Create mailmap file for improved git author logs.

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,0 +1,18 @@
+Jonas Hörsch <hoersch@fias.uni-frankfurt.de>
+Jonas Hörsch <hoersch@fias.uni-frankfurt.de> Jonas Hoersch <jonas@chaoflow.net>
+Jonas Hörsch <hoersch@fias.uni-frankfurt.de> Jonas Hoersch <coroa@posteo.de>
+Jonas Hörsch <hoersch@fias.uni-frankfurt.de> Jonas Hörsch <coroa@posteo.de>
+Jonas Hörsch <hoersch@fias.uni-frankfurt.de> Jonas Hörsch <jonas@chaoflow.net>
+
+Michael Davidson <mrdavidson@ucsd.edu>
+Michael Davidson <mrdavidson@ucsd.edu> Michael Davidson <michd@mit.edu>
+
+Jiahe Feng (Jeffrey) <fengjiahe1999@gmail.com>
+Jiahe Feng (Jeffrey) <fengjiahe1999@gmail.com> jeffrey7377 <fengjiahe1999@gmail.com>
+Jiahe Feng (Jeffrey) <fengjiahe1999@gmail.com> jeffrey7377 <51950358+jeffrey7377@users.noreply.github.com>
+Jiahe Feng (Jeffrey) <fengjiahe1999@gmail.com> j1feng <51950358+j1feng@users.noreply.github.com>
+Jiahe Feng (Jeffrey) <fengjiahe1999@gmail.com> Jiahe Feng (Jeffrey) <51950358+j1feng@users.noreply.github.com>
+
+Tom Brown <tom@nworbmot.org>
+Tom Brown <tom@nworbmot.org> Tom Brown <brown@fias.uni-frankfurt.de>
+Tom Brown <tom@nworbmot.org> Tom Brown <tombrown@nworbmot.org>


### PR DESCRIPTION
This makes `git shortlog -sne` provide cleaner authorship info by grouping all authors who have used multiple emails over time under a single entry.

Before:

```
(base) (master)blanca[geodata]> git shortlog -sne
   212  willhonaker <wcbhonaker@gmail.com>
    78  Jonas Hörsch <hoersch@fias.uni-frankfurt.de>
    65  Jonas Hoersch <jonas@chaoflow.net>
    48  Michael Davidson <mrdavidson@ucsd.edu>
    44  jeffrey7377 <fengjiahe1999@gmail.com>
    44  j1feng <51950358+j1feng@users.noreply.github.com>
    34  Michael Davidson <michd@mit.edu>
    19  jeffrey7377 <51950358+jeffrey7377@users.noreply.github.com>
...
```

After:

```
(geodata) (master)blanca[geodata]> git shortlog -sne
   212  willhonaker <wcbhonaker@gmail.com>
   151  Jonas Hörsch <hoersch@fias.uni-frankfurt.de>
   116  Jiahe Feng (Jeffrey) <fengjiahe1999@gmail.com>
    82  Michael Davidson <mrdavidson@ucsd.edu>
    22  Tom Brown <tom@nworbmot.org>
    14  euronion <42553970+euronion@users.noreply.github.com>
    11  Markus Schlott <schlott@users.fias.science>
```

Folks on your team can later tweak that file if they prefer their "canonical" email in the logs to be different.