### PR TITLE
[Fix] Support Multi-file Requests with ERA5

### DIFF
--- a/.github/workflows/dev_test.yml
+++ b/.github/workflows/dev_test.yml
@@ -30,12 +30,6 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
-      - name: Get GDAL for Mac OS
-        run: |
-          brew install gdal
-          pip uninstall -y rasterio
-          pip install rasterio
-        if: ${{ matrix.os == 'macos-latest' }}
       - name: Configure CDS API Key (Linux/Mac OS)
         run: |
           echo "${{ secrets.CDS_API_KEY }}" | base64 -d > ~/.cdsapirc

--- a/.github/workflows/pr_test.yml
+++ b/.github/workflows/pr_test.yml
@@ -30,12 +30,6 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
-      - name: Get GDAL for Mac OS
-        run: |
-          brew install gdal
-          pip uninstall -y rasterio
-          pip install rasterio
-        if: ${{ matrix.os == 'macos-latest' }}
       - name: Configure CDS API Key (Linux/Mac OS)
         run: |
           echo "${{ secrets.CDS_API_KEY }}" | base64 -d > ~/.cdsapirc

--- a/src/geodata/datasets/era5.py
+++ b/src/geodata/datasets/era5.py
@@ -204,14 +204,14 @@ def api_hourly_era5(
                     ) as zip_ref:
                         zip_ref.extractall(tempdir)
 
-                    ds = xr.open_mfdataset(
+                    with xr.open_mfdataset(
                         [
                             os.path.join(tempdir, f)
                             for f in os.listdir(tempdir)
                             if f.endswith(".nc")
                         ]
-                    )
-                    ds.to_netcdf(f[1])
+                    ) as ds:
+                        ds.to_netcdf(f[1])
 
                     logger.info("Preprocessing complete with zipfile")
                     logger.info("Successfully downloaded to %s", f[1])

--- a/src/geodata/datasets/era5.py
+++ b/src/geodata/datasets/era5.py
@@ -25,6 +25,8 @@ import calendar
 import glob
 import logging
 import os
+import tempfile
+import zipfile
 from pathlib import Path
 from typing import Iterable
 
@@ -189,9 +191,36 @@ def api_hourly_era5(
                 len(full_request["variable"]),
                 f,
             )
-            full_result.download(f[1])
-            logger.info("Successfully downloaded to %s", f[1])
-            downloadedFiles.append((f[0], f[1]))
+
+            if full_result.content_type == "application/zip":
+                logger.info(
+                    "Multiple files found with request. Additional unzipping/preprocessing needed."
+                )
+
+                with tempfile.TemporaryDirectory() as tempdir:
+                    full_result.download(os.path.join(tempdir, "download.zip"))
+                    with zipfile.ZipFile(
+                        os.path.join(tempdir, "download.zip"), "r"
+                    ) as zip_ref:
+                        zip_ref.extractall(tempdir)
+
+                    ds = xr.open_mfdataset(
+                        [
+                            os.path.join(tempdir, f)
+                            for f in os.listdir(tempdir)
+                            if f.endswith(".nc")
+                        ]
+                    )
+                    ds.to_netcdf(f[1])
+
+                    logger.info("Preprocessing complete with zipfile")
+                    logger.info("Successfully downloaded to %s", f[1])
+                    downloadedFiles.append((f[0], f[1]))
+
+            else:
+                full_result.download(f[1])
+                logger.info("Successfully downloaded to %s", f[1])
+                downloadedFiles.append((f[0], f[1]))
 
 
 def api_monthly_era5(


### PR DESCRIPTION
ERA5 now outputs its result in multiple files with `wind_solar_hourly` config. We therefore need to unzip and merge the netCDF files ourselves rather than saving the zipped file directly.